### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/inst/stan/chunks/densities.stan
+++ b/inst/stan/chunks/densities.stan
@@ -1,18 +1,18 @@
-real lower_normal_lpdf(real y, real mean, real sd, real lower) {
-  return(normal_lpdf(y | mean, sd) - normal_lccdf(lower | mean, sd));
+real lower_normal_lpdf(real y, real mean, real sd, real input_lower) {
+  return(normal_lpdf(y | mean, sd) - normal_lccdf(input_lower | mean, sd));
 }
 
-real upper_normal_lpdf(real y, real mean, real sd, real upper) {
-  return(normal_lpdf(y | mean, sd) - normal_lcdf(upper | mean, sd));
+real upper_normal_lpdf(real y, real mean, real sd, real input_upper) {
+  return(normal_lpdf(y | mean, sd) - normal_lcdf(input_upper | mean, sd));
 }
 
-real inner_normal_lpdf(real y, real mean, real sd, real lower, real upper) {
+real inner_normal_lpdf(real y, real mean, real sd, real input_lower, real input_upper) {
   return(normal_lpdf(y | mean, sd) -
-         log(normal_cdf(upper, mean, sd) -
-             normal_cdf(lower, mean, sd)));
+         log(normal_cdf(input_upper | mean, sd) -
+             normal_cdf(input_lower | mean, sd)));
 }
 
-real double_normal_lpdf(real y, real mean, real sd, real lower, real upper) {
+real double_normal_lpdf(real y, real mean, real sd, real input_lower, real input_upper) {
   return(normal_lpdf(y | mean, sd) -
-         log(normal_cdf(upper, mean, sd) + normal_cdf(-lower, -mean, sd)));
+         log(normal_cdf(input_upper | mean, sd) + normal_cdf(-input_lower | -mean, sd)));
 }

--- a/inst/stan/chunks/phma_likelihoods.stan
+++ b/inst/stan/chunks/phma_likelihoods.stan
@@ -1,9 +1,9 @@
 #include /chunks/densities.stan
 
-real phma_normal_lpdf(real x, real theta, real sigma, real [] alpha, vector eta) {
+real phma_normal_lpdf(real x, real theta, real sigma, array[] real alpha, vector eta) {
   int k = size(alpha);
-  real y[k - 1];
-  real u = (1 - normal_cdf(x, 0, sigma));
+  array[k - 1] real y;
+  real u = (1 - normal_cdf(x | 0, sigma));
   real cutoff;
 
   for(i in 1:(k - 2)){

--- a/inst/stan/chunks/psma_likelihoods.stan
+++ b/inst/stan/chunks/psma_likelihoods.stan
@@ -4,17 +4,17 @@
 // likelihood.
 
 real normal_lnorm(real theta, real tau, real sigma,
-                  real [] alpha, vector eta) {
+                  array[] real alpha, vector eta) {
   int k = size(alpha);
   real cutoff;
   real cdf;
-  real summands[k - 1];
+  array[k - 1] real summands;
 
   summands[1] = eta[1];
 
   for(i in 2:(k - 1)) {
     cutoff = inv_Phi(1 - alpha[i])*sigma;
-    cdf = normal_cdf(cutoff, theta, sqrt(tau * tau + sigma * sigma));
+    cdf = normal_cdf(cutoff | theta, sqrt(tau * tau + sigma * sigma));
     summands[i] = cdf*(eta[i] - eta[i - 1]);
   }
 
@@ -27,17 +27,17 @@ real normal_lnorm(real theta, real tau, real sigma,
 // normalizing constant.
 
 real psma_normal_prior_mini_lpdf(real theta, real theta0, real tau, real sigma,
-                                 real [] alpha, vector eta) {
+                                 array[] real alpha, vector eta) {
   real y = normal_lpdf(theta | theta0, tau);
   real normalizer = normal_lnorm(theta0, tau, sigma, alpha, eta);
   return(y - normalizer);
 }
 
 real psma_normal_mini_lpdf(real x, real theta, real sigma,
-                           real [] alpha, vector eta) {
+                           array[] real alpha, vector eta) {
   int k = size(alpha);
   real y = normal_lpdf(x | theta, sigma);
-  real u = (1 - normal_cdf(x, 0, sigma));
+  real u = (1 - normal_cdf(x | 0, sigma));
 
   for(i in 1:(k - 1)){
     if(alpha[i] < u && u <= alpha[i + 1]) {
@@ -50,7 +50,7 @@ real psma_normal_mini_lpdf(real x, real theta, real sigma,
 }
 
 real psma_normal_maxi_lpdf(real x, real theta, real sigma,
-                           real [] alpha, vector eta) {
+                           array[] real alpha, vector eta) {
   real y = psma_normal_mini_lpdf(x | theta, sigma, alpha, eta);
   real normalizer = normal_lnorm(theta, 0, sigma, alpha, eta);
   return(y - normalizer);
@@ -59,11 +59,11 @@ real psma_normal_maxi_lpdf(real x, real theta, real sigma,
 // This is the marginal lpdf as in Hedges' paper.
 
 real psma_normal_marginal_lpdf(real x, real theta0, real tau, real sigma,
-                               real [] alpha, vector eta) {
+                               array[] real alpha, vector eta) {
 
   int k = size(alpha);
   real y = normal_lpdf(x | theta0, sqrt(tau * tau + sigma * sigma));
-  real u = (1 - normal_cdf(x, 0, sigma));
+  real u = (1 - normal_cdf(x | 0, sigma));
   real normalizer = normal_lnorm(theta0, tau, sigma, alpha, eta);
 
   for(i in 1:(k - 1)){

--- a/inst/stan/cma.stan
+++ b/inst/stan/cma.stan
@@ -7,9 +7,9 @@ data {
   // Input data.
   int<lower = 0> N;   // Number of observations.
   int<lower = 0> k;   // Length of alpha.
-  real alpha[k];      // The vector of cuttoffs.
-  real yi[N];         // The estimated effect sizes.
-  real vi[N];         // The study-specific variances.
+  array[k] real alpha;      // The vector of cuttoffs.
+  array[N] real yi;         // The estimated effect sizes.
+  array[N] real vi;         // The study-specific variances.
 
   // Prior parameters.
   vector[k - 1] eta0;
@@ -28,7 +28,7 @@ data {
 parameters {
   real theta0;
   real <lower = 0> tau;
-  real theta[N];
+  array[N] real theta;
 
 }
 

--- a/inst/stan/phma.stan
+++ b/inst/stan/phma.stan
@@ -7,9 +7,9 @@ data {
   // Input data.
   int<lower = 0> N;   // Number of observations.
   int<lower = 0> k;   // Length of alpha.
-  real alpha[k];      // The vector of cuttoffs.
-  real yi[N];         // The estimated effect sizes.
-  real vi[N];         // The study-specific variances.
+  array[k] real alpha;      // The vector of cuttoffs.
+  array[N] real yi;         // The estimated effect sizes.
+  array[N] real vi;         // The study-specific variances.
 
   // Prior parameters.
   vector[k - 1] eta0;
@@ -28,7 +28,7 @@ data {
 
 parameters {
   real theta0;
-  real theta[N];
+  array[N] real theta;
   real <lower = 0> tau;
   simplex[k - 1] eta;
 

--- a/inst/stan/psma.stan
+++ b/inst/stan/psma.stan
@@ -7,9 +7,9 @@ data {
   // Input data.
   int<lower = 0> N;   // Number of observations.
   int<lower = 0> k;   // Length of alpha.
-  real alpha[k];      // The vector of cuttoffs.
-  real yi[N];         // The estimated effect sizes.
-  real vi[N];         // The study-specific variances.
+  array[k] real alpha;      // The vector of cuttoffs.
+  array[N] real yi;         // The estimated effect sizes.
+  array[N] real vi;         // The study-specific variances.
 
   // Prior parameters.
   vector[k - 1] eta0;
@@ -30,7 +30,7 @@ parameters {
   real theta0;
   real <lower = 0> tau;
   positive_ordered[k - 1] weights;
-  real theta[N];
+  array[N] real theta;
 
 }
 


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `lower` is a reserved keyword, changed to `input_lower`
- `upper` is a reserved keyword, changed to `input_upper`
- `_cdf` functions using conditional `|` notation (i.e., `_cdf(y |x)`)

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
